### PR TITLE
Run Pull Request Monitor at 1pm in addition to 7am

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,7 +2,7 @@ name: Run Pull Request Monitor
 on:
   workflow_dispatch:
   schedule:
-    - cron: '2 7 * * *'
+    - cron: '2 7,13 * * *'
 jobs:
 
   run-tdr:


### PR DESCRIPTION
It makes it easier to find PRs that need reviewing that have been created since 7am. 1pm was chosen because it's right after lunch.